### PR TITLE
Validate Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monocloud/sdk-js-core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "MonoCloud SDK Javascript Core Library",
   "keywords": [
     "monocloud",

--- a/src/base/monocloud-client-base.ts
+++ b/src/base/monocloud-client-base.ts
@@ -12,22 +12,34 @@ export abstract class MonoCloudClientBase {
     baseUrl?: string,
     instance?: AxiosInstance
   ) {
-    const headers: Record<string, string> = {
-      'X-TENANT-ID': configuration.tenantId,
-      'X-API-KEY': configuration.apiKey,
-      'Content-Type': 'application/json',
-    };
+    if (instance) {
+      this.instance = instance;
+    } else {
+      if (!configuration.tenantId) {
+        throw new MonoCloudException('Tenant Id is required');
+      }
 
-    const config: AxiosRequestConfig = {
-      baseURL: baseUrl !== undefined && baseUrl !== null ? baseUrl : '',
-      headers,
-      timeout: configuration.config?.timeout ?? 10000,
-    };
+      if (!configuration.apiKey) {
+        throw new MonoCloudException('Api Key is required');
+      }
 
-    this.instance = instance || axios.create(config);
+      const headers: Record<string, string> = {
+        'X-TENANT-ID': configuration.tenantId,
+        'X-API-KEY': configuration.apiKey,
+        'Content-Type': 'application/json',
+      };
 
-    if (configuration.config?.retry === true) {
-      axiosRetry(this.instance, { retries: 3 });
+      const config: AxiosRequestConfig = {
+        baseURL: baseUrl !== undefined && baseUrl !== null ? baseUrl : '',
+        headers,
+        timeout: configuration.config?.timeout ?? 10000,
+      };
+
+      this.instance = axios.create(config);
+
+      if (configuration.config?.retry === true) {
+        axiosRetry(this.instance, { retries: 3 });
+      }
     }
   }
 

--- a/src/base/monocloud-config.ts
+++ b/src/base/monocloud-config.ts
@@ -1,6 +1,6 @@
 export type MonoCloudConfig = {
-  tenantId: string;
-  apiKey: string;
+  tenantId?: string;
+  apiKey?: string;
   config?: {
     timeout?: number;
     retry?: boolean;


### PR DESCRIPTION
- Api Key and Tenant Id are now optional.

- If an Instance of axios is passed through the constructor, It is expected to have be configured by the developer. No changes are made on the instance. 

- If no axios instance is passed through the constructor, the config is validated and `tenantId` and `apiKey` is required. In this case timeout and retry remains optional and takes default value of `10000ms` for timeout and `zero retries`.