### PR TITLE
Added MonoCloudBaseException

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monocloud/sdk-js-core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "MonoCloud SDK Javascript Core Library",
   "keywords": [
     "monocloud",

--- a/src/exceptions/bad-request-exception.ts
+++ b/src/exceptions/bad-request-exception.ts
@@ -1,5 +1,6 @@
+import { MonoCloudBaseException } from './monocloud-base-exception';
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export class BadRequestException extends Error {
+export class BadRequestException extends MonoCloudBaseException {
   constructor(public readonly message: string, public readonly raw: any) {
     super(message);
   }

--- a/src/exceptions/conflict-exception.ts
+++ b/src/exceptions/conflict-exception.ts
@@ -1,5 +1,7 @@
+import { MonoCloudBaseException } from './monocloud-base-exception';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export class ConflictException extends Error {
+export class ConflictException extends MonoCloudBaseException {
   constructor(
     public readonly message: string,
     public readonly errors: string[],

--- a/src/exceptions/forbidden-exception.ts
+++ b/src/exceptions/forbidden-exception.ts
@@ -1,5 +1,7 @@
+import { MonoCloudBaseException } from './monocloud-base-exception';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export class ForbiddenException extends Error {
+export class ForbiddenException extends MonoCloudBaseException {
   constructor(public readonly message: string, public readonly raw: any) {
     super(message);
   }

--- a/src/exceptions/model-state-exception.ts
+++ b/src/exceptions/model-state-exception.ts
@@ -1,5 +1,7 @@
+import { MonoCloudBaseException } from './monocloud-base-exception';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export class ModelStateException<T = any> extends Error {
+export class ModelStateException<T = any> extends MonoCloudBaseException {
   constructor(
     public readonly message: string,
     public readonly errors: ModelStateError<T>,

--- a/src/exceptions/monocloud-base-exception.ts
+++ b/src/exceptions/monocloud-base-exception.ts
@@ -1,0 +1,1 @@
+export class MonoCloudBaseException extends Error {}

--- a/src/exceptions/monocloud-exception.ts
+++ b/src/exceptions/monocloud-exception.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { unflatten } from 'flat';
+import { MonoCloudBaseException } from './monocloud-base-exception';
 import { BadRequestException } from './bad-request-exception';
 import { ResourceExhaustedException } from './resource-exhausted-exception';
 import { ForbiddenException } from './forbidden-exception';
@@ -10,7 +11,7 @@ import { UnauthorizedException } from './unauthorized-exception';
 import { ModelStateError, ModelStateException } from './model-state-exception';
 import { ConflictException } from './conflict-exception';
 
-export class MonoCloudException extends Error {
+export class MonoCloudException extends MonoCloudBaseException {
   constructor(public readonly message: string) {
     super();
   }

--- a/src/exceptions/not-found-exception.ts
+++ b/src/exceptions/not-found-exception.ts
@@ -1,5 +1,7 @@
+import { MonoCloudBaseException } from './monocloud-base-exception';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export class NotFoundException extends Error {
+export class NotFoundException extends MonoCloudBaseException {
   constructor(public readonly message: string, public readonly raw: any) {
     super(message);
   }

--- a/src/exceptions/resource-exhausted-exception.ts
+++ b/src/exceptions/resource-exhausted-exception.ts
@@ -1,5 +1,7 @@
+import { MonoCloudBaseException } from './monocloud-base-exception';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export class ResourceExhaustedException extends Error {
+export class ResourceExhaustedException extends MonoCloudBaseException {
   constructor(public readonly message: string, public readonly raw: any) {
     super(message);
   }

--- a/src/exceptions/server-error-exception.ts
+++ b/src/exceptions/server-error-exception.ts
@@ -1,4 +1,6 @@
-export class ServerErrorException extends Error {
+import { MonoCloudBaseException } from './monocloud-base-exception';
+
+export class ServerErrorException extends MonoCloudBaseException {
   constructor(public readonly message: string, public readonly status: number) {
     super(message);
   }

--- a/src/exceptions/unauthorized-exception.ts
+++ b/src/exceptions/unauthorized-exception.ts
@@ -1,1 +1,3 @@
-export class UnauthorizedException extends Error {}
+import { MonoCloudBaseException } from './monocloud-base-exception';
+
+export class UnauthorizedException extends MonoCloudBaseException {}


### PR DESCRIPTION
- Added MonoCloudBaseException so that developers can use `error instanceof MonoCloudBaseException` and catch all errors that comes form MonoCloud Sdks